### PR TITLE
🚚 move to `ddev` domain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
 jobs:
   tests:
     defaults:
@@ -47,15 +47,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'
@@ -65,7 +65,7 @@ jobs:
         mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
 
     - name: Download docker images
-      run: | 
+      run: |
         mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null && ddev delete -Oy junk
     - name: tmate debugging session
       uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![tests](https://github.com/drud/ddev-elasticsearch/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-elasticsearch/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-elasticsearch/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-elasticsearch/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## Installation
 
 Uses [elasticsearch official image](https://hub.docker.com/_/elasticsearch)
 
-`ddev get drud/ddev-elasticsearch`
+`ddev get ddev/ddev-elasticsearch`
 
 ## Configuration
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -31,8 +31,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get drud/ddev-elasticsearch with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-elasticsearch
+  echo "# ddev get ddev/ddev-elasticsearch with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-elasticsearch
   ddev restart
   ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
 }


### PR DESCRIPTION
This PR updates docs and tests for move to `ddev` domain.