### PR TITLE
The 'name' matters in DDEV v1.22.0, make it 'elasticsearch'

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: ddev-elasticsearch
+name: elasticsearch
 
 pre_install_actions:
 


### PR DESCRIPTION
## The Issue

The 'name' matters in DDEV v1.22.0, make it 'elasticsearch' #14

