### PR TITLE
[#15] add elasticsearch 8 support, fixes #15, fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Uses [elasticsearch official image](https://hub.docker.com/_/elasticsearch)
 
 `ddev get ddev/ddev-elasticsearch`
 
+### Using Elasticsearch 8
+
+Post `ddev get`, run `cp .ddev/elasticsearch/docker-compose.elasticsearch8.yaml .ddev/` to enable Elasticsearch 8.
+
 ## Configuration
 
 From within the container, the elasticsearch container is reached at hostname: "elasticsearch", port: 9200, so the server URL might be `http://elasticsearch:9200`. You can also use the "ddev.site" http and https urls to access it: `http://<projectname>.ddev.site:9200`, and `https://<projectname>.ddev.site:9201`

--- a/docker-compose.elasticsearch.yaml
+++ b/docker-compose.elasticsearch.yaml
@@ -22,7 +22,7 @@ services:
       - elasticsearch:/usr/share/elasticsearch/data
       - ".:/mnt/ddev_config"
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail -s localhost:9200"]
+      test: ["CMD-SHELL", "curl --fail -s elasticsearch:9200"]
 
 volumes:
   elasticsearch:

--- a/elasticsearch/config/elasticsearch8.yml
+++ b/elasticsearch/config/elasticsearch8.yml
@@ -1,0 +1,15 @@
+#ddev-generated
+# This file contains the configuration settings for Elasticsearch 8.
+# For more information, see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name
+cluster.name: "docker-cluster"
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#network.host
+network.host: 0.0.0.0
+
+# Disable security features
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#general-security-settings
+xpack.security.enabled: false
+xpack.security.autoconfiguration.enabled: false
+xpack.security.enrollment.enabled: false

--- a/elasticsearch/docker-compose.elasticsearch8.yaml
+++ b/elasticsearch/docker-compose.elasticsearch8.yaml
@@ -1,0 +1,6 @@
+#ddev-generated
+services:
+  elasticsearch:
+    image: elasticsearch:8.10.2
+    volumes:
+      - ./elasticsearch/config/elasticsearch8.yml:/usr/share/elasticsearch/config/elasticsearch.yml

--- a/install.yaml
+++ b/install.yaml
@@ -4,4 +4,5 @@ pre_install_actions:
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
+- elasticsearch/
 - docker-compose.elasticsearch.yaml


### PR DESCRIPTION
## The Issue
Elasticsearch 8 does not work currently, because of the failing health check. More info at 
* #15. 

See also
* #1 

## How This PR Solves The Issue
It adds the ability to use elasticsearch 8
Tested versions:
- 7.17.6
- 7.17.13
- 8.5.3
- 8.10.2

## Manual Testing Instructions
Follow the install instructions in the updated README sections.

## Automated Testing Overview
The current implementation does not require any change to the current testing.

## Related Issue Link(s)
#15 

## Release/Deployment Notes

Does not affect anything else or has ramifications for other code. Nothing must be done on deployment.

