### PR TITLE
enable version 8 release test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -47,8 +47,7 @@ teardown() {
   execute_test
 }
 
-# enable after release of https://github.com/ddev/ddev-elasticsearch/pull/16
-# @test "install version 8 from release" {
-#   USE_VERSION8=true
-#   execute_test
-# }
+@test "install version 8 from release" {
+  USE_VERSION8=true
+  execute_test
+}


### PR DESCRIPTION
## Description

It enables the `install version 8 from release` test that came along with #16.

## Automated Testing Overview

The GitHub Actions must be green.

## Related Issue Link(s)

[#16 ](https://github.com/ddev/ddev-elasticsearch/pull/16#issuecomment-1791054300)

## Release/Deployment Notes

Just test improvement.

