### PR TITLE
update elasticsearch to 7.17.14

### DIFF
--- a/docker-compose.elasticsearch.yaml
+++ b/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:7.17.6
+    image: elasticsearch:7.17.14
     expose:
       - "9200"
       - "9300"


### PR DESCRIPTION
## The Issue

There are critical vulnerabilities for the current 7.17.6 which is a year-old release.

## How This PR Solves The Issue

Updated to the latest stable version of the 7.17.x series.

## Manual Testing Instructions

Bats tests must pass.

## Automated Testing Overview

No new tests needed since features did not change.

## Release/Deployment Notes

Nothing needs to be done.

