### PR TITLE
docs: update ddev get  to ddev add-on get in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,21 @@
 
 Uses [elasticsearch official image](https://hub.docker.com/_/elasticsearch)
 
-`ddev get ddev/ddev-elasticsearch`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ddev/ddev-elasticsearch
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get ddev/ddev-elasticsearch
+```
 
 ### Using Elasticsearch 8
 
-Post `ddev get`, run `cp .ddev/elasticsearch/docker-compose.elasticsearch8.yaml .ddev/` to enable Elasticsearch 8.
+After adding the add-on, run `cp .ddev/elasticsearch/docker-compose.elasticsearch8.yaml .ddev/` to enable Elasticsearch 8.
 
 ## Connection
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.