### PR TITLE
feat: add ELASTICSEARCH_DOCKER_IMAGE

### DIFF
--- a/docker-compose.elasticsearch.yaml
+++ b/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:7.17.14
+    image: ${ELASTICSEARCH_DOCKER_IMAGE:-elasticsearch:7.17.14}
     expose:
       - "9200"
       - "9300"
@@ -12,12 +12,12 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - VIRTUAL_HOST=${DDEV_HOSTNAME}
       - HTTP_EXPOSE=9200:9200
       - HTTPS_EXPOSE=9201:9200
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
       - ".:/mnt/ddev_config"

--- a/elasticsearch/docker-compose.elasticsearch8.yaml
+++ b/elasticsearch/docker-compose.elasticsearch8.yaml
@@ -1,6 +1,6 @@
 #ddev-generated
 services:
   elasticsearch:
-    image: elasticsearch:8.10.2
+    image: ${ELASTICSEARCH_DOCKER_IMAGE:-elasticsearch:8.10.2}
     volumes:
       - ./elasticsearch/config/elasticsearch8.yml:/usr/share/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
## The Issue

If people want to do a minor bump, they can use `.ddev/.env.elasticsearch` file.

## How This PR Solves The Issue

Allows minor version overrides.

Tests updates will be in the next PR.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-elasticsearch/tarball/20250411_stasadev_image
ddev dotenv set .ddev/.env.elasticsearch --elasticsearch-docker-image=elasticsearch:7.17.14
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
