### PR TITLE
chore(update-checker): .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# This should follow https://github.com/ddev/ddev/blob/main/.editorconfig
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+# Forcing indent to 4 seems to break lots of things, like
+# embedded yaml in markdown.
+# indent_size = 4
+insert_final_newline = true
+
+# GO files
+[*.go]
+indent_style = tab
+
+# Makefile
+[Makefile]
+indent_style = tab
+
+# Script files
+[*.sh]
+indent_size = 2
+
+# NSIS files
+[*.{nsi,nsh}]
+end_of_line = crlf
+indent_size = 2
+
+[*schema.json]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,34 +1,15 @@
-# This should follow https://github.com/ddev/ddev/blob/main/.editorconfig
-
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 charset = utf-8
 end_of_line = lf
+indent_size = 4
 indent_style = space
-# Forcing indent to 4 seems to break lots of things, like
-# embedded yaml in markdown.
-# indent_size = 4
 insert_final_newline = true
+trim_trailing_whitespace = true
 
-# GO files
-[*.go]
-indent_style = tab
+[*.md]
+trim_trailing_whitespace = false
 
-# Makefile
-[Makefile]
-indent_style = tab
-
-# Script files
-[*.sh]
-indent_size = 2
-
-# NSIS files
-[*.{nsi,nsh}]
-end_of_line = crlf
-indent_size = 2
-
-[*schema.json]
+[*.{bats,sh,yml,yaml}]
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore
+.editorconfig export-ignore


### PR DESCRIPTION
## The Issue

(I didn't create an issue for this)

I was working on a shell script for a different merge request, and noticed that my editor's defaults didn't match ddev conventions. I went looking for a `.editorconfig` and didn't find one in this repo.

## How This PR Solves The Issue

I copied [the `.editorconfig` from ddev/ddev](https://github.com/ddev/ddev/blob/9e1a27142e830b55da9b82ab53c8e1590dc7be3a/.editorconfig) at commit `9e1a27142e830b55da9b82ab53c8e1590dc7be3a` (which was the HEAD of `main` at time-of-writing) into this repo.


## Manual Testing Instructions

1. Clone this branch
2. Create a new `.sh` file in the project using [an editor that supports the EditorConfig standard](https://editorconfig.org/#pre-installed) with default configuration
3. Press the `tab` key:
    - **Expected behavior**: your cursor is indented 2 spaces
    - **Previous behavior**:  your cursor is indented by something else (for me it was 4 spaces; but depending on the editor, it could be 8 spaces or 1 tab)


## Automated Testing Overview

I don't think automatically testing text editors is within the scope of the ddev project, although I suppose, if desired, I could try to figure out how to write a browser-based test for a browser-based editor like VSCode, although I feel that would be very brittle and would unnecessarily extend the scope of this issue.


## Release/Deployment Notes

Only affects people trying to contribute to this add-on.

Nothing needs to be done on deployment.
