### PR TITLE
chore: run `ddev utility addon-update-checker`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-elasticsearch/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
     - cron: '25 08 * * *'
@@ -19,9 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:

--- a/install.yaml
+++ b/install.yaml
@@ -4,4 +4,4 @@ project_files:
   - elasticsearch/
   - docker-compose.elasticsearch.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'


### PR DESCRIPTION
## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Bumps version constraint to v1.24.10

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
